### PR TITLE
feat: a11y, validation, tests, and mobile transitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
         run: npm ci
       - name: Lint
         run: npm run lint
+      - name: Unit Test
+        run: npm run test:unit
       - name: Build
         run: npm run build
         env:

--- a/__tests__/example.test.ts
+++ b/__tests__/example.test.ts
@@ -1,7 +1,0 @@
-import { describe, it, expect } from 'vitest'
-
-describe('示例测试', () => {
-  it('基本断言应通过', () => {
-    expect(1 + 1).toBe(2)
-  })
-})

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { cn, formatCurrency, formatDate, generateId } from '@/lib/utils';
+
+describe('cn', () => {
+  it('merges classes', () => {
+    expect(cn('a', 'b')).toBe('a b');
+  });
+  it('handles conditional classes', () => {
+    expect(cn('base', false && 'hidden', 'block')).toBe('base block');
+  });
+});
+
+describe('formatCurrency', () => {
+  it('formats positive amount', () => {
+    expect(formatCurrency(1234.56)).toMatch(/¥/);
+    expect(formatCurrency(1234.56)).toMatch(/1,?234\.56/);
+  });
+  it('formats zero', () => {
+    expect(formatCurrency(0)).toMatch(/0\.00/);
+  });
+});
+
+describe('formatDate', () => {
+  it('formats ISO date', () => {
+    expect(formatDate('2024-06-15')).toMatch(/2024/);
+    expect(formatDate('2024-06-15')).toMatch(/15/);
+  });
+});
+
+describe('generateId', () => {
+  it('returns a non-empty string', () => {
+    const id = generateId();
+    expect(typeof id).toBe('string');
+    expect(id.length).toBeGreaterThan(0);
+  });
+  it('returns unique values', () => {
+    const ids = new Set(Array.from({ length: 10 }, generateId));
+    expect(ids.size).toBe(10);
+  });
+});

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -71,6 +71,7 @@ export default function Navbar({ user }: Props) {
             className="md:hidden p-2 rounded-lg hover:bg-zinc-100 transition-colors"
             onClick={() => setMobileOpen(!mobileOpen)}
             aria-label="切换菜单"
+            aria-expanded={mobileOpen}
           >
             <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               {mobileOpen ? (
@@ -81,36 +82,38 @@ export default function Navbar({ user }: Props) {
             </svg>
           </button>
         </div>
-        {mobileOpen && (
-          <div className="md:hidden border-t border-zinc-200 bg-white">
-            {navItems.map((item) => {
-              const Icon = item.icon;
-              const active = pathname === item.href;
-              return (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  onClick={() => setMobileOpen(false)}
-                  className={`flex items-center gap-3 px-4 py-3 text-sm font-medium transition-colors ${
-                    active ? 'bg-zinc-900 text-white' : 'text-zinc-600 hover:bg-zinc-50'
-                  }`}
-                >
-                  <Icon className="w-4 h-4" />
-                  {item.label}
-                </Link>
-              );
-            })}
-            {user && (
-              <button
-                onClick={() => { logout(); setMobileOpen(false); }}
-                className="flex items-center gap-3 px-4 py-3 text-sm font-medium text-red-600 hover:bg-zinc-50 w-full"
+        <div
+          className={`md:hidden border-t border-zinc-200 bg-white overflow-hidden transition-all duration-300 ease-in-out ${
+            mobileOpen ? 'max-h-80 opacity-100' : 'max-h-0 opacity-0'
+          }`}
+        >
+          {navItems.map((item) => {
+            const Icon = item.icon;
+            const active = pathname === item.href;
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                onClick={() => setMobileOpen(false)}
+                className={`flex items-center gap-3 px-4 py-3 text-sm font-medium transition-colors ${
+                  active ? 'bg-zinc-900 text-white' : 'text-zinc-600 hover:bg-zinc-50'
+                }`}
               >
-                <LogOut className="w-4 h-4" />
-                退出登录
-              </button>
-            )}
-          </div>
-        )}
+                <Icon className="w-4 h-4" />
+                {item.label}
+              </Link>
+            );
+          })}
+          {user && (
+            <button
+              onClick={() => { logout(); setMobileOpen(false); }}
+              className="flex items-center gap-3 px-4 py-3 text-sm font-medium text-red-600 hover:bg-zinc-50 w-full"
+            >
+              <LogOut className="w-4 h-4" />
+              退出登录
+            </button>
+          )}
+        </div>
       </header>
       <div className="h-16" />
     </>

--- a/components/transaction-form.tsx
+++ b/components/transaction-form.tsx
@@ -10,6 +10,10 @@ interface Props {
   onSuccess?: () => void;
 }
 
+function isValidAmount(value: string): boolean {
+  return /^\d+(\.\d{1,2})?$/.test(value.trim());
+}
+
 export default function TransactionForm({ categories, onSuccess }: Props) {
   const [type, setType] = useState<TransactionType>('EXPENSE');
   const [amount, setAmount] = useState('');
@@ -24,9 +28,14 @@ export default function TransactionForm({ categories, onSuccess }: Props) {
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError('');
+
+    if (!isValidAmount(amount)) {
+      setError('请输入有效的金额（最多两位小数）');
+      return;
+    }
     const numAmount = parseFloat(amount);
-    if (!numAmount || numAmount <= 0 || !isFinite(numAmount)) {
-      setError('请输入有效的金额');
+    if (numAmount <= 0 || !isFinite(numAmount)) {
+      setError('金额必须大于 0');
       return;
     }
     if (!categoryId) {
@@ -55,10 +64,11 @@ export default function TransactionForm({ categories, onSuccess }: Props) {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="bg-white rounded-xl border border-zinc-200 p-5 shadow-sm">
-      <div className="flex items-center gap-3 mb-5">
+    <form onSubmit={handleSubmit} className="bg-white rounded-xl border border-zinc-200 p-5 shadow-sm" aria-label="记账表单">
+      <div className="flex items-center gap-3 mb-5" role="group" aria-label="交易类型">
         <button
           type="button"
+          aria-pressed={type === 'EXPENSE'}
           onClick={() => { setType('EXPENSE'); setCategoryId(''); }}
           className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all cursor-pointer ${
             type === 'EXPENSE'
@@ -71,6 +81,7 @@ export default function TransactionForm({ categories, onSuccess }: Props) {
         </button>
         <button
           type="button"
+          aria-pressed={type === 'INCOME'}
           onClick={() => { setType('INCOME'); setCategoryId(''); }}
           className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all cursor-pointer ${
             type === 'INCOME'
@@ -87,21 +98,23 @@ export default function TransactionForm({ categories, onSuccess }: Props) {
           <label htmlFor="amount" className="block text-sm font-medium text-zinc-700 mb-1.5">金额</label>
           <input
             id="amount"
-            type="number"
-            step="0.01"
+            type="text"
+            inputMode="decimal"
             value={amount}
             onChange={(e) => setAmount(e.target.value)}
             placeholder="0.00"
+            aria-invalid={!!error && error.includes('金额')}
             className="w-full px-3 py-2.5 rounded-lg border border-zinc-300 text-zinc-900 placeholder:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
           />
         </div>
         <div>
-          <p className="block text-sm font-medium text-zinc-700 mb-1.5">分类</p>
-          <div className="flex flex-wrap gap-2">
+          <p id="category-label" className="block text-sm font-medium text-zinc-700 mb-1.5">分类</p>
+          <div className="flex flex-wrap gap-2" role="group" aria-labelledby="category-label">
             {filteredCategories.map((cat) => (
               <button
                 key={cat.id}
                 type="button"
+                aria-pressed={categoryId === cat.id}
                 onClick={() => setCategoryId(cat.id)}
                 className={`px-3 py-1.5 rounded-full text-xs font-medium transition-all cursor-pointer ${
                   categoryId === cat.id
@@ -138,7 +151,7 @@ export default function TransactionForm({ categories, onSuccess }: Props) {
             />
           </div>
         </div>
-        {error && <p className="text-sm text-red-600">{error}</p>}
+        {error && <p className="text-sm text-red-600" role="alert">{error}</p>}
         <button
           type="submit"
           disabled={loading}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
+import path from 'path'
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname),
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
-
 export default defineConfig({
   plugins: [react()],
   test: {
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./vitest.setup.ts'],
+    exclude: ['node_modules', 'e2e'],
   },
 })


### PR DESCRIPTION
Cherry-picks valuable improvements from #9 / #11 that still apply after the Vercel Postgres migration (#10).

## Changes

- **transaction-form**: Strict amount validation (regex ), a11y attrs (, , , )
- **navbar**: Smooth mobile menu transition with  +  animation
- **CI**: Run 
> my-account@0.1.0 test:unit
> vitest run before build
- **tests**: Add unit tests for  (, , , )

## Excluded (architecturally obsolete)

- Store closure fixes →  removed in #10
-  hook → no longer needed with Server Components
- Prisma removal → now required by #10
- Page-level category sync fixes → pages are now Server Components

Closes #9