### PR TITLE
ci: fix Vercel deployment project linkage

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,4 +24,6 @@ jobs:
       - name: Deploy to Vercel
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: team_wgZ52ilGmid7GdSY7EVLQcvB
+          VERCEL_PROJECT_ID: prj_ssLTdGoVzxw4HCJyRED2Szb69KOe
         run: npx vercel --prod --token "$VERCEL_TOKEN" --yes


### PR DESCRIPTION
Add VERCEL_ORG_ID and VERCEL_PROJECT_ID so the CLI knows which project to deploy to.