### PR TITLE
ci: add workflow_dispatch for manual deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,6 @@
 name: Deploy
 on:
+  workflow_dispatch:
   push:
     branches: [main]
 jobs:


### PR DESCRIPTION
Allow manual triggering of deploy workflow to test the new VERCEL_TOKEN.