### PR TITLE
chore: 全面升级项目环境到 Node.js 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/bcryptjs": "^3.0.0",
         "@types/jsonwebtoken": "^9.0.10",
-        "@types/node": "^20",
+        "@types/node": "^22",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^6.0.1",
@@ -43,6 +43,9 @@
         "typescript": "^5",
         "vercel": "^53.1.0",
         "vitest": "^4.1.5"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3261,9 +3264,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmmirror.com/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmmirror.com/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/bcryptjs": "^3.0.0",
     "@types/jsonwebtoken": "^9.0.10",
-    "@types/node": "^20",
+    "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6.0.1",
@@ -53,5 +53,8 @@
     "*.{js,jsx,ts,tsx}": [
       "eslint --fix"
     ]
+  },
+  "engines": {
+    "node": ">=22.0.0"
   }
 }


### PR DESCRIPTION
## 变更内容

本次 PR 完成 Issue #20 中要求的全面升级到 Node.js 22：

### GitHub Actions 升级
- `.github/workflows/ci.yml`：`actions/checkout@v4` → `actions/checkout@v6`
- `.github/workflows/ci.yml`：`actions/setup-node@v4` → `actions/setup-node@v6`
- `.github/workflows/deploy.yml`：`actions/checkout@v4` → `actions/checkout@v6`
- `.github/workflows/deploy.yml`：`actions/setup-node@v4` → `actions/setup-node@v6`

### package.json 更新
- 新增 `engines` 字段，明确声明 `node: ">=22.0.0"`
- 升级 `@types/node` 从 `^20` 到 `^22`

### 兼容性验证
- ✅ `npm install` 成功
- ✅ `npm run lint` 通过
- ✅ `npm run test:unit` 通过
- ✅ `npm run build` 成功

所有依赖（Next.js 16、Prisma 5、React 19 等）与 Node.js 22 完全兼容。

Closes #20
