### PR TITLE
fix: add pull_request trigger to deploy workflow for status check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -23,6 +22,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Install latest Vercel CLI
+        if: github.event_name != 'pull_request'
         run: npm install -g vercel@latest
       - name: Build
         run: npm run build
@@ -31,6 +31,7 @@ jobs:
           POSTGRES_PRISMA_URL: postgresql://mock:mock@localhost:5432/mock
           JWT_SECRET: ci-mock-secret-for-build-only
       - name: Deploy to Vercel
+        if: github.event_name != 'pull_request'
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: team_wgZ52ilGmid7GdSY7EVLQcvB

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,10 +5,13 @@ name: Deploy
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Problem

PR #61 merge fails with: `Required status check "deploy" is expected.`

deploy.yml only triggers on `push` to main and `workflow_dispatch`, but branch protection requires deploy as a required status check on PRs.

## Fix

1. Add `pull_request` trigger (branches: [main]) to deploy.yml
2. Add `if: github.event_name != 'pull_request'` condition to ensure actual deployment only runs on push to main and workflow_dispatch

Closes #60

---
**Note:** This PR must be merged before PR #61.